### PR TITLE
Archiver Viewer Updates

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -27,7 +27,8 @@ const Alert: React.FC<AlertProps> = ({ level, message, title, extra }) => {
   return visible ? (
     <S.Wrapper level={level} opacity={opacity}>
       <S.Title>
-        {title} &bull; <S.Extra>{extra}</S.Extra>
+        {title}<br/>
+        <S.Extra>{extra}</S.Extra>
       </S.Title>
       <S.Message>{message}</S.Message>
     </S.Wrapper>

--- a/src/components/Alert/styled.tsx
+++ b/src/components/Alert/styled.tsx
@@ -9,13 +9,13 @@ interface AlertWrapperProps {
 const getBGColorFromLevel = (level: MessageLevel) => {
   switch (level) {
     case MessageLevel.info:
-      return "lightblue";
+      return "#46c4ffAA";
     case MessageLevel.error:
-      return "#ff9e9e";
+      return "#ff9e9eAA";
     case MessageLevel.warn:
-      return "#feffaa";
+      return "#feffaaAA";
     default:
-      return "lightgrey";
+      return "#a8a8a8AA";
   }
 };
 
@@ -25,17 +25,19 @@ export const Wrapper = styled.div<AlertWrapperProps>`
   background-color: ${({ level }) => getBGColorFromLevel(level)};
   transition: opacity 0.5s;
   opacity: ${({ opacity }) => opacity};
+  border-radius: 0.5em;
 `;
 export const Title = styled.h1`
-  font-size: 1.05rem;
+  font-size: 0.85rem;
   font-weight: 500;
   margin-bottom: 0.5rem;
 `;
 export const Message = styled.p`
-  font-size: 0.95rem;
+  font-size: 0.75rem;
+  width: 40em;
 `;
 export const Extra = styled.span`
   padding: 5px;
-  font-size: 0.85rem;
+  font-size: 0.80rem;
   font-weight: 400;
 `;

--- a/src/components/AlertDisplay/styled.tsx
+++ b/src/components/AlertDisplay/styled.tsx
@@ -7,9 +7,8 @@ export const Wrapper = styled.div<WarpperProps>`
   display: ${({ $display }) => ($display ? "block" : "none")};
   margin-left: auto;
   margin-right: auto;
+  position: absolute;
   right: 0;
-  left: 0;
-  top: 80%;
   text-align: center;
   z-index: 5;
 `;

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -36,8 +36,8 @@ const App: React.FC = () => {
       </S.HeaderWrapper>
       <SearchResults />
       <Info />
-      <LineChart />
       <AlertDisplay />
+      <LineChart />
       <S.FooterWrapper>
         <Loading />
         <Entries />

--- a/src/components/Controls/index.tsx
+++ b/src/components/Controls/index.tsx
@@ -138,7 +138,9 @@ class Controls extends Component<ControlsReduxProps, ControlsState> {
   };
 
   handleTimeRefChange = (e: any) => {
-    handlers.updateReferenceTime(parseInt(e.target.value) === 1);
+    const isEndSelected = parseInt(e.target.value) === 1;
+    handlers.updateReferenceTime(isEndSelected);
+    this.handleDateChange(this.state.startDate);
   };
 
   renderLeftGroup = () => {

--- a/src/components/Entries/index.tsx
+++ b/src/components/Entries/index.tsx
@@ -41,13 +41,20 @@ const Entries: React.FC = () => {
       pv: { optimized, diff, bins },
     } = datasetInfo;
 
+    function showUnit(): string {
+      if(yAxisID  != label){
+        return yAxisID;
+      }
+      return '';
+    }
+
     return (
       <S.EntryGroup key={label}>
         <S.Color title="Dataset visibility" $bgcolor={backgroundColor} onClick={() => hideDataset(label)}>
           {visible ? <S.VisibleIndicator /> : <S.HiddenIndicator />}
         </S.Color>
         <S.Text title="PV name">{label}</S.Text>
-        <S.EguText title="y axis label">{yAxisID}</S.EguText>
+        <S.EguText title="y axis label">{showUnit()}</S.EguText>
         <Checkbox
           onClick={() => diffHandler(label, !diff)}
           checked={diff}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as S from "./styled";
 
-const version = "2022-07-04-2dd41db";
+const version = "2022-08-29-1ceacac";
 
 const Footer: React.FC = () => {
   return (

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as S from "./styled";
 
-const version = "2022-08-29-1ceacac";
+const version = "2022-09-06-cabf52d";
 
 const Footer: React.FC = () => {
   return (

--- a/src/components/LineChart/config.ts
+++ b/src/components/LineChart/config.ts
@@ -50,7 +50,7 @@ export const options: Chart.ChartOptions = {
           autoSkipPadding: 5,
           maxRotation: 0,
           minRotation: 0,
-          stepSize: 1,
+          stepSize: 1
         }
       }
     ],

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { connect, useSelector } from "react-redux";
+import { connect } from "react-redux";
 import { Chart } from "chart.js";
 
 import UrlLoader from "../../controllers/UrlLoader";

--- a/src/components/Series/index.tsx
+++ b/src/components/Series/index.tsx
@@ -26,7 +26,7 @@ const Series: React.FC = () => {
     }
 
     const val = parseFloat(yMinState);
-    if (val) {
+    if (!isNaN(val)) {
       ChartController.setAxisYMin(id, val);
     }
   };
@@ -41,7 +41,7 @@ const Series: React.FC = () => {
     }
 
     const val = parseFloat(yMaxState);
-    if (val) {
+    if(!isNaN(val)){
       ChartController.setAxisYMax(id, val);
     }
   };

--- a/src/components/Series/index.tsx
+++ b/src/components/Series/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import Checkbox from "../Checkbox";
 
 import * as S from "./styled";

--- a/src/controllers/handlers.ts
+++ b/src/controllers/handlers.ts
@@ -419,5 +419,5 @@ export default {
   exportAsXlsx,
   undoHandler,
   redoHandler,
-  updateReferenceTime,
+  updateReferenceTime
 };

--- a/src/entities/Chart/impl.ts
+++ b/src/entities/Chart/impl.ts
@@ -768,7 +768,8 @@ class ChartImpl implements ChartInterface {
 
   loadTooltipSettings() {
     const singleTipCookie = Browser.getCookie("singleTip");
-    this.setSingleTipEnabled(singleTipCookie === "true" || singleTipCookie == null);
+    this.setSingleTipEnabled(singleTipCookie === "true" ||
+                              singleTipCookie == '');
     this.chartjs.toggleTooltipBehavior(this.singleTipEnabled);
   }
 

--- a/src/features/chart/initialState.ts
+++ b/src/features/chart/initialState.ts
@@ -18,7 +18,7 @@ const initialState: ChartState = {
   autoScroll: false,
   dataAxis: [], // @todo: Transform into an object
   datasets: [], // @todo: Transform into an object
-  singleTooltip: false,
+  singleTooltip: true,
   timeEnd: null,
   timeReferenceEnd: true,
   timeStart: null,

--- a/src/use-cases/QueryPVs/impl.ts
+++ b/src/use-cases/QueryPVs/impl.ts
@@ -21,7 +21,6 @@ function isValidPVMetadata(pvMetadata: ArchiverMetadata): boolean {
 
 function isPromisseFulfilled(result: any): boolean {
   if (!result) {
-    console.log(result);
     return false;
   }
   if (result.status !== "fulfilled" || result.value === null || result.value === undefined) {


### PR DESCRIPTION
Some updates on the Archiver Viewer Interface:
 - Show All in Tooltip enabled by default: Show the tooltip on hover any data point.
 - Update on change interval reference time: Update chart and time interval on switch between the 'Start' and 'End' for the reference time of the intervals. 
 - Solve Manual Y Lmits with 0 as value: Now it is possible to use 0 as a value for the Manual Y Limits.
 - Don't show anything as unit on label of the PV, if the PV doesn't have a unit value.
 - Alert style changes
![image](https://user-images.githubusercontent.com/63302930/187238866-6c5fa3c5-5aca-48fc-8877-5d69a1721556.png)


